### PR TITLE
ViewCommand: Update UI

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindPolicyCommand.java
@@ -8,7 +8,7 @@ import seedu.address.model.Model;
 import seedu.address.model.person.PolicyNameContainsKeywordsPredicate;
 
 /**
- * Finds and lists all persons in the address book whose policy name contains any of the specified keywords.
+ * Finds and lists all persons in the address book who have policy names containing any of the specified keywords.
  */
 public class FindPolicyCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -50,8 +50,6 @@ public class ViewCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireAllNonNull(model);
 
-        // Update the filtered person list to display all persons
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         List<Person> lastShownList = model.getFilteredPersonList();
         logger.info("Current list size: " + lastShownList.size() + ", target index : " + index.getOneBased());
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -154,7 +154,6 @@ public class MainWindow extends UiPart<Stage> {
         }
     }
 
-
     /**
      * Opens the help window or focuses on it if it's already opened.
      */
@@ -211,13 +210,6 @@ public class MainWindow extends UiPart<Stage> {
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
-            if (commandResult instanceof ViewCommandResult) {
-                ViewCommandResult viewCommandResult = (ViewCommandResult) commandResult;
-                showPolicyList(new HashSet<>(viewCommandResult.getPolicies())); // Assuming Set<Policy> to ObservableList<Policy> conversion if necessary
-            } else {
-                hidePolicyList();
-            }
-
             if (commandResult.isShowHelp()) {
                 handleHelp();
             }
@@ -230,6 +222,13 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
 
+            if (commandResult instanceof ViewCommandResult) {
+                ViewCommandResult viewCommandResult = (ViewCommandResult) commandResult;
+                showPolicyList(new HashSet<>(viewCommandResult.getPolicies()));
+            } else {
+                hidePolicyList();
+            }
+
             return commandResult;
         } catch (CommandException | ParseException e) {
             logger.info("An error occurred while executing command: " + commandText);
@@ -238,14 +237,23 @@ public class MainWindow extends UiPart<Stage> {
         }
     }
 
+    /**
+     * Expands the policy list panel and shows the policy list.
+     * @param policies Policies to be shown in the policy list panel.
+     */
     private void showPolicyList(HashSet<Policy> policies) {
         policyListPanel = new PolicyListPanel(policies);
+        policyListPanel.setPrefSize(680, 680);
         policyListPanelPlaceholder.getChildren().clear();
         policyListPanelPlaceholder.getChildren().add(policyListPanel.getRoot());
         policyListPanelPlaceholder.setVisible(true);
     }
 
+    /**
+     * Collapses the policy list panel and hides the policy list.
+     */
     private void hidePolicyList() {
+        policyListPanel.setPrefSize(0,0);
         policyListPanelPlaceholder.setVisible(false);
     }
 

--- a/src/main/java/seedu/address/ui/PolicyListPanel.java
+++ b/src/main/java/seedu/address/ui/PolicyListPanel.java
@@ -34,6 +34,10 @@ public class PolicyListPanel extends UiPart<Region> {
         policyListView.setCellFactory(listView -> new PolicyListViewCell());
     }
 
+    public void setPrefSize(double width, double height) {
+        policyListView.setPrefSize(width, height);
+    }
+
     /**
      * Custom {@code ListCell} that displays the graphics of a {@code Policy} using a {@code PolicyCard}.
      */


### PR DESCRIPTION
'view' command expands PolicyListPanel but other commands do not collapse the panel back to original size.
Update: Now, other commands collapse the PolicyListPanel.

Fix indexing issue with ViewCommand.