### PR TITLE
Fix a bug in Meeting class

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -355,13 +355,24 @@ These are some proposed features that can be implemented in the future.
 
 #### Adding a policy displays it in the Policies panel
 
-- Proposed implementation: Modify CommandResult to have an `isAddPolicy()` method. In the MainWindow class, modify `executeCommand` - if the command result isAddPolicy, display the newly added policy in the PolicyListPanel.
+- A possible implementation: Modify CommandResult to have an `isAddPolicy()` method. In the MainWindow class, modify `executeCommand` - if the command result isAddPolicy, display the newly added policy in the PolicyListPanel.
 - This feature would allow users to easily check the details of the newly added policy, without having to look through the user feedback box.
 
 #### Delete policies using the policy's index in Policies panel
 
 - This feature would allow users to easily delete policies, without having to type out the whole policy number.
 
+#### Improving allowed inputs
+Change the allowed inputs for certain fields so that they make logical sense.
+
+- Improve allowed inputs for phone number (ensure it is 8 digits long and starts with 6, 8 or 9)
+- Improve allowed input for phone number and email fields (ensure that these fields are unique across clients)
+
+#### Fixing text out of boundaries in UI
+- Right now, long input fields may cause text to be cut off in the UI, e.g. a long client name might get cut off in the UI with `...`
+- This can be fixed by either:
+  - limiting the number of characters allowed in the name. This is not ideal as certain clients may in fact have very long names, and we should allow these names too.
+  - fixing UI such that text out of boundaries are wrapped. This is the better solution.
 ---
 
 ## **Documentation, logging, testing, configuration, dev-ops**

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -210,7 +210,7 @@ Meeting field input <strong>MUST</strong> be a date and time in the future!
 
 MEETING_TIME <strong>MUST</strong> be unique!
 
-Name <strong>MUST</strong> be alphanumeric characters only!
+Name <strong>MUST</strong> be alphanumeric characters only, and unique across clients!
 
 PHONE_NUMBER <strong>MUST</strong> be numeric characters only! <strong> Min: 3 characters</strong>
 </div>
@@ -219,7 +219,7 @@ PHONE_NUMBER <strong>MUST</strong> be numeric characters only! <strong> Min: 3 c
 
 <div style="border: 1px solid #28a745; background-color: #d4edda; padding: 10px; border-radius: 5px;">
 <span style="font-size: 20px; color: #007bff;">&#x1F4A1;</span> <strong>Tip:</strong>
-It is optional for the client to have tags. A client can have any number of tags (including 0). TAG <strong>MUST</strong> be alphanumeric characters only!
+It is optional for the client to have tags. A client can have any number of tags (including 0). TAG <strong>MUST</strong> be alphanumeric characters only (space is not allowed)!
 </div>
 
 <br/>

--- a/src/main/java/seedu/address/model/person/Meeting.java
+++ b/src/main/java/seedu/address/model/person/Meeting.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
@@ -87,6 +88,7 @@ public class Meeting implements Comparable<Meeting> {
         }
         try {
             LocalDate dateCheck = LocalDate.parse(dateTime.substring(0, 10)); // Check that the date is valid.
+            LocalTime timeCheck = LocalTime.parse(dateTime.substring(11)); // Check that the time is valid.
             return LocalDateTime.parse(dateTime, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
         } catch (DateTimeParseException e) {
             throw new IllegalArgumentException(MESSAGE_CONSTRAINTS);

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
+    public static final String MESSAGE_CONSTRAINTS = "Tag names should be alphanumeric and can't contain spaces";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final String tagName;

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tag names should be alphanumeric and can't contain spaces";
+    public static final String MESSAGE_CONSTRAINTS = "Tag names should be alphanumeric";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final String tagName;


### PR DESCRIPTION
Fixed a bug that allows 24:00 as a valid time (interpreted as 00:00 on the next date)

Justification: This is allowed as, per v1.3 app, when users add a duplicate meeting, the app shows: "This meeting already exists in the address book."
As our app promises that meetings must be unique, users may wonder why adding "2024-05-10 24:00" and "2024-05-11 00:00" is not allowed. This fix ensures that meetings are unique in InsureBook.